### PR TITLE
feat: add Talent Platform metrics dashboard (#36)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/icons-material": "^7.3.5",
         "@mui/material": "^7.3.5",
         "@mui/material-nextjs": "^7.3.9",
+        "@mui/x-charts": "^9.0.1",
         "@mui/x-data-grid": "^8.27.4",
         "@mui/x-date-pickers": "^8.27.2",
         "@prisma/client": "^6.19.0",
@@ -363,9 +364,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2055,6 +2056,149 @@
       "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
       "license": "MIT"
     },
+    "node_modules/@mui/x-charts": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/x-charts/-/x-charts-9.0.1.tgz",
+      "integrity": "sha512-0LyhlGhUm07wGJY0d0U+hSljGS1EHKWgPBsTJ/lBNGDrNc4DI9zSbp4h802LN/eLwMUVXJSI7DH2W3Ef3WsqnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@mui/utils": "9.0.0",
+        "@mui/x-charts-vendor": "^9.0.0",
+        "@mui/x-internal-gestures": "^9.0.0",
+        "@mui/x-internals": "^9.0.0",
+        "bezier-easing": "^2.1.0",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^7.3.0 || ^9.0.0",
+        "@mui/system": "^7.3.0 || ^9.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-charts-vendor": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-charts-vendor/-/x-charts-vendor-9.0.0.tgz",
+      "integrity": "sha512-Do91i+fZiNj/4LN5oaGpJoutolzDBDwdfw6tHrx2LKXDMCRlaImCfreLbdbkk7dFsi9fuIP7hWiMV4vDJKPJTA==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@types/d3-array": "^3.2.2",
+        "@types/d3-color": "^3.1.3",
+        "@types/d3-format": "^3.0.4",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-path": "^3.1.1",
+        "@types/d3-scale": "^4.0.9",
+        "@types/d3-shape": "^3.1.8",
+        "@types/d3-time": "^3.0.4",
+        "@types/d3-time-format": "^4.0.3",
+        "@types/d3-timer": "^3.0.2",
+        "d3-array": "^3.2.4",
+        "d3-color": "^3.1.0",
+        "d3-format": "^3.1.2",
+        "d3-interpolate": "^3.0.1",
+        "d3-path": "^3.1.0",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.2.0",
+        "d3-time": "^3.1.0",
+        "d3-time-format": "^4.1.0",
+        "d3-timer": "^3.0.1",
+        "flatqueue": "^3.0.0",
+        "internmap": "^2.0.3"
+      }
+    },
+    "node_modules/@mui/x-charts/node_modules/@mui/types": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.0.0.tgz",
+      "integrity": "sha512-i1cuFCAWN44b3AJWO7mh7tuh1sqbQSeVr/94oG0TX5uXivac8XalgE4/6fQZcmGZigzbQ35IXxj/4jLpRIBYZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-charts/node_modules/@mui/utils": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.0.0.tgz",
+      "integrity": "sha512-bQcqyg/gjULUqTuyUjSAFr6LQGLvtkNtDbJerAtoUn9kGZ0hg5QJiN1PLHMLbeFpe3te1831uq7GFl2ITokGdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/types": "^9.0.0",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-charts/node_modules/@mui/x-internals": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-9.0.0.tgz",
+      "integrity": "sha512-E/4rdg69JjhyybpPGypCjAKSKLLnSdCFM+O6P/nkUg47+qt3uftxQEhjQO53rcn6ahHl6du/uNZ9BLgeY6kYxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@mui/utils": "9.0.0",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@mui/x-charts/node_modules/react-is": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "license": "MIT"
+    },
     "node_modules/@mui/x-data-grid": {
       "version": "8.27.4",
       "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-8.27.4.tgz",
@@ -2157,6 +2301,15 @@
         "moment-jalaali": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@mui/x-internal-gestures": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internal-gestures/-/x-internal-gestures-9.0.0.tgz",
+      "integrity": "sha512-+fW1EUai25GJbivGRsi3GX4GYsSvzFPvUEjmMgB4POkRBDjrEZNaLdVWfapT6DlWv/Vfbi08bYSuyvhPXGMZjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6"
       }
     },
     "node_modules/@mui/x-internals": {
@@ -2869,6 +3022,75 @@
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
       "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
     "node_modules/@types/debug": {
@@ -3943,6 +4165,12 @@
         "bcrypt": "bin/bcrypt"
       }
     },
+    "node_modules/bezier-easing": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bezier-easing/-/bezier-easing-2.1.0.tgz",
+      "integrity": "sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -4354,6 +4582,118 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -5508,6 +5848,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/flatqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/flatqueue/-/flatqueue-3.0.0.tgz",
+      "integrity": "sha512-y1deYaVt+lIc/d2uIcWDNd0CrdQTO5xoCjeFdhX0kSXvm2Acm0o+3bAOiYklTEoRyzwio3sv3/IiBZdusbAe2Q==",
+      "license": "ISC"
+    },
     "node_modules/flatted": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
@@ -6085,6 +6431,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-alphabetical": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@mui/icons-material": "^7.3.5",
     "@mui/material": "^7.3.5",
     "@mui/material-nextjs": "^7.3.9",
+    "@mui/x-charts": "^9.0.1",
     "@mui/x-data-grid": "^8.27.4",
     "@mui/x-date-pickers": "^8.27.2",
     "@prisma/client": "^6.19.0",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -187,7 +187,6 @@ async function seedAppAccessRules(apps: any, tiers: Map<string, number>) {
 async function seedSpecificRolesAndUsers() {
   console.log('\nSeeding Roles and Specific Users for Issue #14...');
 
-  // 1. 确保角色存在
   const roles = ['ADMIN', 'STUDENT', 'RECRUITER'];
   const roleMap = new Map();
   for (const r of roles) {
@@ -226,15 +225,15 @@ async function seedSpecificRolesAndUsers() {
         firstName: `Student${i}`,
         lastName: 'UCL',
         roles: { create: { roleId: roleMap.get('STUDENT') } },
-        // 满足 "Populate StudentProfile records" 要求
+
         studentProfile: {
           create: { bio: `I am student number ${i}` }
         },
-        // 满足 "varying consent states" 和 "at least one student has consent records" 要求
+
         consents: i === 1 ? undefined : {
           create: {
             type: 'PRIVACY_POLICY',
-            accepted: i === 2 // 学生2同意，学生3拒绝
+            accepted: i === 2 
           }
         },
         studentSkills: {
@@ -291,28 +290,31 @@ async function seedSpecificRolesAndUsers() {
       },
     });
 
+    const recruiterRoleId = roleMap.get('RECRUITER');
+
     const user = await prisma.user.upsert({
       where: { email: r.email },
-      update: { userStatus: r.userStatus },
       create: {
         email: r.email,
         passwordHash: commonPassword,
-        firstName: 'Recruiter',
-        lastName: r.companyStatus === 'APPROVED' ? 'Active' : 'Pending',
-        userStatus: r.userStatus,
+        firstName: 'Test',
+        lastName: 'Recruiter',
         organisationId: org.id,
-        roles: { create: { roleId: roleMap.get('RECRUITER') } },
-        memberships: {
-          create: {
-            organisationId: org.id,
-            membershipTierId: goldTier.id,
-            status: r.membershipStatus,
-            isActive: r.isActive,
-          },
-        },
+        roles: { create: { roleId: recruiterRoleId } },
+      },
+      update: {
+        organisationId: org.id,
       },
     });
-    console.log(`  - Seeded recruiter ${user.email} (userStatus=${r.userStatus}, org=${org.name})`);
+
+    await prisma.userRole.upsert({
+      where: {
+        userId_roleId: { userId: user.id, roleId: recruiterRoleId }
+      },
+      update: {},
+      create: { userId: user.id, roleId: recruiterRoleId }
+    });
+    console.log(`  User id=${user.id}, email=${user.email}, role=RECRUITER`);
   }
 }
 
@@ -369,6 +371,12 @@ async function main() {
 
     const passwordHash = await hashPassword(m.credentials.password);
 
+    const recruiterRole = await prisma.role.upsert({
+      where: { key: 'RECRUITER' },
+      update: {},
+      create: { key: 'RECRUITER', label: 'Recruiter' },
+    });
+    
     const user = await prisma.user.upsert({
       where: { email: m.credentials.email },
       create: {
@@ -377,6 +385,7 @@ async function main() {
         firstName: m.company.contact_first,
         lastName: m.company.contact_last,
         organisationId: organisation.id,
+        roles: { create: { roleId: recruiterRole.id } },
       },
       update: {
         firstName: m.company.contact_first,
@@ -385,6 +394,15 @@ async function main() {
         passwordHash,
       },
     });
+
+    await prisma.userRole.upsert({
+      where: {
+        userId_roleId: { userId: user.id, roleId: recruiterRole.id }
+      },
+      update: {},
+      create: { userId: user.id, roleId: recruiterRole.id }
+    });
+    
     console.log(`  User id=${user.id}, email=${user.email}`);
 
     const tierId = tierIdByYaml.get(m.membership.tier);

--- a/src/app/api/admin/metrics/route.ts
+++ b/src/app/api/admin/metrics/route.ts
@@ -1,0 +1,66 @@
+// src/app/api/admin/metrics/route.ts
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getServerAuthSession } from "@/lib/getServerAuthSession";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const session = await getServerAuthSession();
+    
+    const user = session?.user as { id?: string; roleKeys?: string[] } | undefined;
+    const roleKeys: string[] = user?.roleKeys ?? [];
+    
+    if (!user?.id || !roleKeys.includes("ADMIN")) {
+      return NextResponse.json({ error: "Admin access required." }, { status: 403 });
+    }
+
+    const totalStudents = await prisma.user.count({
+      where: {
+        roles: {
+          some: { role: { key: "STUDENT" } }
+        }
+      }
+    });
+
+    const consentedRecords = await prisma.studentCompanyConsent.findMany({
+      where: { consented: true },
+      distinct: ['studentId'],
+      select: { studentId: true }
+    });
+    const consentedStudents = consentedRecords.length;
+
+    const activeFirms = await prisma.membership.findMany({
+      where: {
+        isActive: true,
+        user: {
+          roles: {
+            some: { role: { key: "RECRUITER" } }
+          }
+        }
+      },
+      distinct: ['organisationId'],
+      select: { organisationId: true }
+    });
+    const approvedFirms = activeFirms.length;
+
+    const matchablePairs = consentedStudents * approvedFirms;
+
+    return NextResponse.json({
+      totalStudents,
+      consentedStudents,
+      approvedFirms,
+      matchablePairs
+    });
+
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    console.error("[API_ERROR] admin-metrics:", errorMessage);
+    
+    return NextResponse.json(
+      { error: "Failed to fetch metrics" }, 
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/membership-dashboard/AdminDashboardClient.tsx
+++ b/src/components/membership-dashboard/AdminDashboardClient.tsx
@@ -13,11 +13,12 @@ import type {
 import type { HandbookRenderResult } from "@/lib/handbook";
 import { canAccessBenefit } from "@/lib/membership-dashboard-admin";
 import { saveRedeemedBenefitsAction } from "@/lib/membership-dashboard-actions";
+import TalentMetricsPanel from "./TalentMetricsPanel";
 
-type TabKey = "members" | "benefits" | "handbook";
+type TabKey = "members" | "benefits" | "handbook" | "metrics";
 
 function asTabKey(v: string | null | undefined): TabKey | null {
-  if (v === "members" || v === "benefits" || v === "handbook") return v;
+  if (v === "members" || v === "benefits" || v === "handbook" || v === "metrics") return v;
   return null;
 }
 
@@ -73,7 +74,7 @@ export default function AdminDashboardClient(props: {
   const bootTab = asTabKey(initialTab) ?? urlTab ?? "members";
   const [activeTab, setActiveTab] = useState<TabKey>(bootTab);
 
-  const ADMIN_TABS: TabKey[] = ["members", "benefits", "handbook"];
+  const ADMIN_TABS: TabKey[] = ["members", "benefits", "handbook", "metrics"];
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   function handleTabKeyDown(e: React.KeyboardEvent, currentIndex: number) {
@@ -266,6 +267,21 @@ export default function AdminDashboardClient(props: {
               onKeyDown={(e) => handleTabKeyDown(e, 2)}
             >
               Handbook
+            </button>
+
+            <button
+              ref={(el) => { tabRefs.current[3] = el; }} // 注意这里是 [3]
+              type="button"
+              role="tab"
+              className={`tab ${activeTab === "metrics" ? "is-active" : ""}`}
+              aria-selected={activeTab === "metrics"}
+              aria-controls="panel-metrics"
+              id="tab-metrics"
+              tabIndex={activeTab === "metrics" ? 0 : -1}
+              onClick={() => changeTab("metrics")}
+              onKeyDown={(e) => handleTabKeyDown(e, 3)} // 注意这里是 3
+            >
+              Talent Platform
             </button>
           </div>
 
@@ -609,7 +625,6 @@ export default function AdminDashboardClient(props: {
                     </button>
                   )}
                 </div>
-
                 {/* No extra title here; Markdown owns the chapter heading */}
                 <div
                   className="markdown-content"
@@ -617,6 +632,16 @@ export default function AdminDashboardClient(props: {
                 />
               </article>
             )}
+          </div>
+          <div
+            role="tabpanel"
+            id="panel-metrics"
+            aria-labelledby="tab-metrics"
+            className="tab-panel tab-panel--scroll"
+            hidden={activeTab !== "metrics"}
+          >
+            <h3 style={{ marginTop: 0 }}>Talent Platform Metrics</h3>
+            {activeTab === "metrics" && <TalentMetricsPanel />}
           </div>
         </div>
       </section>

--- a/src/components/membership-dashboard/TalentMetricsPanel.tsx
+++ b/src/components/membership-dashboard/TalentMetricsPanel.tsx
@@ -1,0 +1,124 @@
+// src/components/membership-dashboard/TalentMetricsPanel.tsx
+"use client";
+
+import { useState, useEffect } from "react";
+import { Box, Card, Typography, Grid, CircularProgress } from "@mui/material";
+import { PieChart } from "@mui/x-charts/PieChart";
+
+// 定义后端返回的数据格式
+interface MetricsData {
+  totalStudents: number;
+  consentedStudents: number;
+  approvedFirms: number;
+  matchablePairs: number;
+}
+
+export default function TalentMetricsPanel() {
+  const [metrics, setMetrics] = useState<MetricsData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // 页面加载时请求数据
+  useEffect(() => {
+    async function fetchMetrics() {
+      try {
+        const res = await fetch("/api/admin/metrics");
+        if (res.ok) {
+          const data = await res.json();
+          setMetrics(data);
+        } else {
+          console.error("[UI_ERROR] Failed to fetch metrics");
+        }
+      } catch (error) {
+        console.error("[UI_ERROR] Network error:", error);
+      } finally {
+        setLoading(false);
+      }
+    }
+    
+    fetchMetrics();
+  }, []);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", mt: 10 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  // 如果请求失败，给个兜底显示
+  if (!metrics) {
+    return <Typography color="error">Failed to load metrics data.</Typography>;
+  }
+
+  // 饼图数据：同意的学生 vs 未同意的学生
+  const chartData = [
+    { id: 0, value: metrics.consentedStudents, label: "Consented", color: "#2e7d32" },
+    { id: 1, value: metrics.totalStudents - metrics.consentedStudents, label: "Not Consented", color: "#e0e0e0" },
+  ];
+
+  return (
+    <Box sx={{ mt: 3 }}>
+      <Grid container spacing={3}>
+        {/* 顶部 4 个统计卡片 */}
+        <Grid item xs={12} sm={6} md={3}>
+          <MetricCard title="Total Students" value={metrics.totalStudents} />
+        </Grid>
+        <Grid item xs={12} sm={6} md={3}>
+          <MetricCard title="Consented Students" value={metrics.consentedStudents} color="#2e7d32" />
+        </Grid>
+        <Grid item xs={12} sm={6} md={3}>
+          <MetricCard title="Approved Firms" value={metrics.approvedFirms} />
+        </Grid>
+        <Grid item xs={12} sm={6} md={3}>
+          <MetricCard title="Matchable Pairs" value={metrics.matchablePairs.toLocaleString()} />
+        </Grid>
+
+        {/* 底部饼图区域 */}
+        <Grid item xs={12} md={6}>
+          <Card sx={{ p: 3, borderRadius: "8px", border: "1px solid #e5e7eb", boxShadow: "none", display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <Typography variant="h6" sx={{ mb: 2, fontWeight: 600 }}>Student Consent Rate</Typography>
+            <PieChart
+              series={[
+                {
+                  data: chartData,
+                  innerRadius: 40, 
+                  outerRadius: 100,
+                  paddingAngle: 2,
+                  cornerRadius: 4,
+                },
+              ]}
+              width={400}
+              height={250}
+              margin={{ right: 5 }}
+            />
+          </Card>
+        </Grid>
+
+        {/* 右侧说明 */}
+        <Grid item xs={12} md={6}>
+            <Card sx={{ p: 3, borderRadius: "8px", border: "1px solid #e5e7eb", boxShadow: "none", height: '100%' }}>
+                <Typography variant="h6" sx={{ mb: 1, fontWeight: 600 }}>About these metrics</Typography>
+                <Typography variant="body2" color="text.secondary">
+                    These metrics represent the "North Star" health of the Talent Platform.
+                    It tracks users who have passed initial verification and can use the platform without friction.
+                </Typography>
+            </Card>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}
+
+function MetricCard({ title, value, color = "#111827" }: { title: string, value: string | number, color?: string }) {
+  return (
+    <Card sx={{ p: 3, borderRadius: "8px", border: "1px solid #e5e7eb", boxShadow: "none" }}>
+      <Typography sx={{ fontSize: 13, fontWeight: 600, color: "#6b7280", textTransform: "uppercase", mb: 1 }}>
+        {title}
+      </Typography>
+      <Typography sx={{ fontSize: 28, fontWeight: 700, color: color }}>
+        {value}
+      </Typography>
+    </Card>
+  );
+}


### PR DESCRIPTION
Added a new Talent Platform tab re-using the existing dashboard tab infrastructure.

Created TalentMetricsPanel to visualize the North Star metrics.
<img width="781" height="571" alt="#36" src="https://github.com/user-attachments/assets/79e80d80-cadd-43b1-be30-d1321f9e3d7b" />


Added api/admin/metrics endpoint to fetch real-time aggregated data (Total Students, Consented Students, Approved Firms, Matchable Pairs).

Added a Donut chart (via @mui/x-charts) to visualize the Student Consent Rate.

Fixed seed data: Updated prisma/seed.ts to correctly assign the RECRUITER role to all seeded partner users so they are accurately counted as approved firms.

Because the database seed logic was updated to fix missing role assignments, please make sure to reset your database and re-run the seed script using **npx prisma db seed** in terminal