### PR TITLE
fix(admin): migrate student/partners dashboard metrics to server-si API

### DIFF
--- a/src/app/api/admin/partner-metrics/route.ts
+++ b/src/app/api/admin/partner-metrics/route.ts
@@ -1,0 +1,71 @@
+// src/app/api/admin/partner-metrics/route.ts
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getServerAuthSession } from "@/lib/getServerAuthSession";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const session = await getServerAuthSession();
+    const user = session?.user as { id?: string; roleKeys?: string[] } | undefined;
+    const roleKeys: string[] = user?.roleKeys ?? [];
+    
+    if (!user?.id || !roleKeys.includes("ADMIN")) {
+      return NextResponse.json({ error: "Admin access required." }, { status: 403 });
+    }
+
+    // 1. 获取所有行业招聘人员，并“顺藤摸瓜”带上他们有效的封禁记录
+    const recruiters = await prisma.user.findMany({
+      where: {
+        organisation: { type: "INDUSTRY" },
+      },
+      select: {
+        userStatus: true,
+        organisation: {
+          select: { status: true },
+        },
+        // 🌟 核心魔法：只查没有被 lifted 的惩罚记录
+        appSuspensions: {
+          where: { liftedAt: null }, 
+          select: { reason: true }
+        }
+      },
+    });
+
+    let active = 0, pending = 0, suspended = 0, banned = 0;
+
+    // 2. 遍历用户，根据真实的 AppSuspension 记录来计算卡片数字
+    recruiters.forEach((u) => {
+      // 根据你数据库截图里的数据规律，reason 字段直接存了操作类型
+      const isBanned = u.appSuspensions.some(s => s.reason === "BANNED");
+      const isSuspended = u.appSuspensions.some(s => s.reason === "SUSPENDED");
+
+      // 优先级：Banned > Suspended > Pending > Active
+      if (isBanned) {
+        banned++;
+      } else if (isSuspended) {
+        suspended++;
+      } else if (u.userStatus === "PENDING_APPROVAL" || u.organisation?.status === "PENDING") {
+        pending++;
+      } else {
+        active++;
+      }
+    });
+
+    return NextResponse.json({
+      active,
+      pending,
+      suspended,
+      banned,
+      total: recruiters.length, // 依然保持准确的总账号人数
+    });
+
+  } catch (error) {
+    console.error("[API_ERROR] partner-metrics:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch partner metrics" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/student-metrics/route.ts
+++ b/src/app/api/admin/student-metrics/route.ts
@@ -1,0 +1,67 @@
+// src/app/api/admin/student-metrics/route.ts
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getServerAuthSession } from "@/lib/getServerAuthSession";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const session = await getServerAuthSession();
+    const user = session?.user as { id?: string; roleKeys?: string[] } | undefined;
+    const roleKeys: string[] = user?.roleKeys ?? [];
+    
+    if (!user?.id || !roleKeys.includes("ADMIN")) {
+      return NextResponse.json({ error: "Admin access required." }, { status: 403 });
+    }
+
+    // 1. 过滤：只找拥有 "STUDENT" 角色的用户！这就彻底隔绝了 Partner 数据。
+    const students = await prisma.user.findMany({
+      where: {
+        roles: {
+          some: { role: { key: "STUDENT" } }
+        }
+      },
+      select: {
+        userStatus: true,
+        // 2. 顺藤摸瓜：只拉取这些学生身上没被解封的惩罚记录
+        appSuspensions: {
+          where: { liftedAt: null },
+          select: { reason: true }
+        }
+      },
+    });
+
+    let active = 0, suspended = 0, banned = 0;
+
+    // 3. 统计逻辑（和 Partner 一样优先判断最严重的）
+    students.forEach((u) => {
+      const isBanned = u.appSuspensions.some(s => s.reason === "BANNED");
+      const isSuspended = u.appSuspensions.some(s => s.reason === "SUSPENDED");
+
+      if (isBanned) {
+        banned++;
+      } else if (isSuspended) {
+        suspended++;
+      } else {
+        // 学生没有 pending 状态，只要没被 ban/suspend 就是 active
+        active++;
+      }
+    });
+
+    // 4. 返回 4 个卡片的数据
+    return NextResponse.json({
+      active,
+      suspended,
+      banned,
+      total: students.length,
+    });
+
+  } catch (error) {
+    console.error("[API_ERROR] student-metrics:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch student metrics" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/membership-dashboard/AdminPartnerManagementPage.tsx
+++ b/src/components/membership-dashboard/AdminPartnerManagementPage.tsx
@@ -12,7 +12,7 @@ import GppBadRoundedIcon from "@mui/icons-material/GppBadRounded";
 import LockPersonRoundedIcon from "@mui/icons-material/LockPersonRounded";
 import VerifiedUserRoundedIcon from "@mui/icons-material/VerifiedUserRounded";
 import BusinessRoundedIcon from "@mui/icons-material/BusinessRounded";
-
+import PendingActionsRoundedIcon from "@mui/icons-material/PendingActionsRounded";
 import UserManagementTable, { type ManagedUser } from "./UserManagementTable";
 import SuspensionHistoryPanel from "./SuspensionHistoryPanel";
 import PendingCompanyApprovalsPanel from "./PendingCompanyApprovalsPanel";
@@ -22,6 +22,7 @@ export default function AdminPartnerManagementPage() {
   const [users, setUsers] = useState<ManagedUser[]>([]);
   const [search, setSearch] = useState("");
   const [selectedUserId, setSelectedUserId] = useState<string>("");
+  const [metrics, setMetrics] = useState({ active: 0, pending: 0, suspended: 0, banned: 0, total: 0 });
 
   useEffect(() => {
     fetch("/api/admin/partners")
@@ -30,6 +31,11 @@ export default function AdminPartnerManagementPage() {
         const safe = Array.isArray(data) ? data : [];
         setUsers(safe);
         setSelectedUserId(safe[0]?.id ?? "");
+      });
+    fetch("/api/admin/partner-metrics")
+      .then((res) => res.json())
+      .then((data) => {
+        if (!data.error) setMetrics(data);
       });
   }, []);
 
@@ -67,7 +73,7 @@ export default function AdminPartnerManagementPage() {
           <Box
             sx={{
               display: "grid",
-              gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
+              gridTemplateColumns: "repeat(5, minmax(0, 1fr))",
               gap: 1.8,
               mb: 2.5,
             }}
@@ -75,15 +81,22 @@ export default function AdminPartnerManagementPage() {
             {[
               {
                 title: "Active partners",
-                value: activeCount,
+                value: metrics.active,
                 note: "Access currently allowed",
                 icon: <VerifiedUserRoundedIcon />,
                 bg: "#eef2ef",
                 color: "#557564",
               },
               {
+                title: "Pending partners",
+                value: metrics.pending, 
+                icon: <PendingActionsRoundedIcon />, 
+                bg: "#eef7ff",
+                color: "#4a7a9e",
+              },
+              {
                 title: "Suspended partners",
-                value: suspendedCount,
+                value: metrics.suspended,
                 note: "Temporary app restriction",
                 icon: <LockPersonRoundedIcon />,
                 bg: "#f3efe8",
@@ -91,15 +104,15 @@ export default function AdminPartnerManagementPage() {
               },
               {
                 title: "Banned partners",
-                value: bannedCount,
+                value: metrics.banned,
                 note: "Permanent restriction",
                 icon: <GppBadRoundedIcon />,
                 bg: "#f4ecec",
                 color: "#865e62",
               },
               {
-                title: "Partner accounts",
-                value: users.length,
+                title: "Total accounts",
+                value: metrics.total,
                 note: "Managed in this scope",
                 icon: <BusinessRoundedIcon />,
                 bg: "#edf1f5",

--- a/src/components/membership-dashboard/AdminStudentManagementPage.tsx
+++ b/src/components/membership-dashboard/AdminStudentManagementPage.tsx
@@ -20,6 +20,7 @@ export default function AdminStudentManagementPage() {
   const [users, setUsers] = useState<ManagedUser[]>([]);
   const [search, setSearch] = useState("");
   const [selectedUserId, setSelectedUserId] = useState<string>("");
+  const [metrics, setMetrics] = useState({ active: 0, suspended: 0, banned: 0, total: 0 });
 
   useEffect(() => {
     fetch("/api/admin/students")
@@ -28,6 +29,12 @@ export default function AdminStudentManagementPage() {
         const safe = Array.isArray(data) ? data : [];
         setUsers(safe);
         setSelectedUserId(safe[0]?.id ?? "");
+      });
+    
+    fetch("/api/admin/student-metrics")
+      .then((res) => res.json())
+      .then((data) => {
+        if (!data.error) setMetrics(data);
       });
   }, []);
 
@@ -40,10 +47,6 @@ export default function AdminStudentManagementPage() {
       user.name.toLowerCase().includes(keyword)
     );
   }, [users, search]);
-
-  const activeCount = users.filter((u) => u.status === "active").length;
-  const suspendedCount = users.filter((u) => u.status === "suspended").length;
-  const bannedCount = users.filter((u) => u.status === "banned").length;
 
   return (
     <Box data-admin-page="student-management">
@@ -73,7 +76,7 @@ export default function AdminStudentManagementPage() {
             {[
               {
                 title: "Active students",
-                value: activeCount,
+                value: metrics.active,
                 note: "Access currently allowed",
                 icon: <VerifiedUserRoundedIcon />,
                 bg: "#eef2ef",
@@ -81,7 +84,7 @@ export default function AdminStudentManagementPage() {
               },
               {
                 title: "Suspended students",
-                value: suspendedCount,
+                value: metrics.suspended,
                 note: "Temporary app restriction",
                 icon: <LockPersonRoundedIcon />,
                 bg: "#f3efe8",
@@ -89,7 +92,7 @@ export default function AdminStudentManagementPage() {
               },
               {
                 title: "Banned students",
-                value: bannedCount,
+                value: metrics.banned,
                 note: "Permanent restriction",
                 icon: <GppBadRoundedIcon />,
                 bg: "#f4ecec",
@@ -97,7 +100,7 @@ export default function AdminStudentManagementPage() {
               },
               {
                 title: "Student accounts",
-                value: users.length,
+                value: metrics.total,
                 note: "Managed in this scope",
                 icon: <SchoolRoundedIcon />,
                 bg: "#edf1f5",


### PR DESCRIPTION
Refactored the AdminStudentManagementPage to fetch metrics from the newly created /api/admin/student-metrics endpoint.

Removed the legacy client-side array filtering logic for active/suspended/banned counts to ensure 100% data accuracy and consistency with the partner management logic.

Fixed a minor React syntax error in the useEffect hook.