### PR TITLE
fix(admin): remove dead count variables from AdminPartnerManagementPage

### DIFF
--- a/src/components/membership-dashboard/AdminPartnerManagementPage.tsx
+++ b/src/components/membership-dashboard/AdminPartnerManagementPage.tsx
@@ -49,10 +49,6 @@ export default function AdminPartnerManagementPage() {
     );
   }, [users, search]);
 
-  const activeCount = users.filter((u) => u.status === "active").length;
-  const suspendedCount = users.filter((u) => u.status === "suspended").length;
-  const bannedCount = users.filter((u) => u.status === "banned").length;
-
   return (
     <Box data-admin-page="partner-management">
           <Stack


### PR DESCRIPTION
activeCount, suspendedCount, and bannedCount were leftover from an earlier page template draft and have since been superseded by the metrics state populated from /api/admin/partner-metrics. They were never rendered in the UI and have now been removed.

Closes #100