### PR TITLE
Fixed the editing organisation type bug causing Errors due to mismatch prisma enums

### DIFF
--- a/src/app/(shell)/membership-dashboard/partner-users/[id]/edit/CompanyProfileForm.tsx
+++ b/src/app/(shell)/membership-dashboard/partner-users/[id]/edit/CompanyProfileForm.tsx
@@ -80,8 +80,8 @@ export default function CompanyProfileForm({
             {isEditing ? (
               <Select fullWidth size="small" value={formData.type} onChange={(e) => setFormData({...formData, type: e.target.value})} disabled={loading}>
                 <MenuItem value="INDUSTRY">INDUSTRY</MenuItem>
-                <MenuItem value="ACADEMIC">ACADEMIC</MenuItem>
-                <MenuItem value="NON_PROFIT">NON_PROFIT</MenuItem>
+                <MenuItem value="UNIVERSITY">UNIVERSITY</MenuItem>
+                <MenuItem value="OTHER">OTHER</MenuItem>
               </Select>
             ) : (
               <Typography>{org?.type || "INDUSTRY"}</Typography>
@@ -95,7 +95,8 @@ export default function CompanyProfileForm({
               <Select fullWidth size="small" value={formData.status} onChange={(e) => setFormData({...formData, status: e.target.value})} disabled={loading}>
                 <MenuItem value="APPROVED">APPROVED</MenuItem>
                 <MenuItem value="PENDING">PENDING</MenuItem>
-                <MenuItem value="REJECTED">REJECTED</MenuItem>
+                <MenuItem value="SUSPENDED">SUSPENDED</MenuItem>
+                <MenuItem value="BANNED">BANNED</MenuItem>
               </Select>
             ) : (
               <Typography>{org?.status || "PENDING"}</Typography>

--- a/src/app/(shell)/membership-dashboard/partner-users/[id]/edit/actions.ts
+++ b/src/app/(shell)/membership-dashboard/partner-users/[id]/edit/actions.ts
@@ -40,8 +40,17 @@ export async function updateOrganisation(orgId: string, userId: string, data: {
   type?: string;
   status?: string;
 }) {
+  // 1. 增加严格的运行时验证 (Runtime Validation)
+  if (data.type && !Object.values(OrganisationType).includes(data.type as OrganisationType)) {
+    throw new Error(`Invalid Organisation Type: ${data.type}`);
+  }
+  if (data.status && !Object.values(CompanyStatus).includes(data.status as CompanyStatus)) {
+    throw new Error(`Invalid Company Status: ${data.status}`);
+  }
+
+  // 2. 验证通过后，安全地存入数据库
   await prisma.organisation.update({
-    where: { id: Number(orgId) },
+    where: { id: orgId },
     data: {
       ...(data.slug   !== undefined && { slug:   data.slug }),
       ...(data.domain !== undefined && { domain: data.domain }),


### PR DESCRIPTION
before it will indicates error and can not save. now its works, can see the picture below.
<img width="783" height="389" alt="image" src="https://github.com/user-attachments/assets/bdf479eb-72d5-4c12-8959-157ee07901a6" />
then
<img width="776" height="329" alt="image" src="https://github.com/user-attachments/assets/cfa4db8b-9488-4dcd-a1c3-d4bd197c4d9f" />
the prisma before editing
<img width="768" height="277" alt="image" src="https://github.com/user-attachments/assets/82a7703b-84a1-4fb5-944a-01ec56918b57" />
now select University and save 
<img width="1526" height="816" alt="image" src="https://github.com/user-attachments/assets/09a8d72d-c678-47eb-b8e7-7a64d4a9e378" />
the prisma for amazon line organisation type become University
<img width="783" height="317" alt="image" src="https://github.com/user-attachments/assets/5764f97f-78e8-4fd5-9a62-a15db4c0210c" />






