### PR TITLE
fix bug in partner management panel, suspend history panel and pending management panel

### DIFF
--- a/src/app/(shell)/membership-dashboard/partner-users/[id]/edit/CompanyProfileForm.tsx
+++ b/src/app/(shell)/membership-dashboard/partner-users/[id]/edit/CompanyProfileForm.tsx
@@ -4,14 +4,21 @@ import { useState } from "react";
 import { Box, Button, TextField, Stack, Typography, MenuItem, Select, Card, Divider } from "@mui/material";
 import { updateOrganisation } from "./actions";
 
+interface OrgProp {
+  id?: number;
+  slug?: string;
+  domain?: string;
+  type?: string;
+  status?: string;
+}
+
 export default function CompanyProfileForm({ 
   org, 
   userId, 
   tier, 
   email 
 }: { 
-  org: any; 
-  userId: string; 
+  org: OrgProp | null;
   tier: string;
   email: string;
 }) {

--- a/src/app/(shell)/membership-dashboard/partner-users/[id]/edit/CompanyProfileForm.tsx
+++ b/src/app/(shell)/membership-dashboard/partner-users/[id]/edit/CompanyProfileForm.tsx
@@ -19,6 +19,7 @@ export default function CompanyProfileForm({
   email 
 }: { 
   org: OrgProp | null;
+  userId: string;
   tier: string;
   email: string;
 }) {

--- a/src/app/(shell)/membership-dashboard/partner-users/[id]/edit/actions.ts
+++ b/src/app/(shell)/membership-dashboard/partner-users/[id]/edit/actions.ts
@@ -4,43 +4,81 @@ import prisma from "@/lib/prisma";
 import { OrganisationType, CompanyStatus } from "@prisma/client";
 import { revalidatePath } from "next/cache";
 
-// Execute suspension or ban
+// Execute suspension or ban (Dual-write: Audit Log + State Update)
 export async function suspendOrBanUser(userId: string, actionType: "SUSPEND" | "BAN") {
-  await prisma.appSuspension.create({
-    data: {
-      userId: userId,
-      appKey: "TALENT_DISCOVERY", 
-      reason: actionType === "BAN" ? "BANNED" : "SUSPENDED", 
-    },
+  // 1. First, find the corresponding organisationId by userId
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { organisationId: true }
+  });
+
+  const targetStatus = actionType === "BAN" ? "BANNED" : "SUSPENDED";
+
+  // 2. Use a transaction to guarantee atomic dual-writes
+  await prisma.$transaction(async (tx) => {
+    // Action A: Create an AppSuspension audit log entry (records the timestamp)
+    await tx.appSuspension.create({
+      data: {
+        userId: userId,
+        appKey: "TALENT_DISCOVERY", 
+        reason: targetStatus, 
+      },
+    });
+
+    // Action B: Sync the status update to the Organisation table
+    if (user?.organisationId) {
+      await tx.organisation.update({
+        where: { id: user.organisationId },
+        data: { status: targetStatus },
+      });
+    }
   });
   
   revalidatePath(`/membership-dashboard/partner-users/${userId}/edit`);
 }
 
-// Lift suspension/ban
+// Lift suspension/ban (Dual-write: Lift Log + State Restore)
 export async function liftSuspension(userId: string) {
-  await prisma.appSuspension.updateMany({
-    where: {
-      userId: userId,
-      appKey: "TALENT_DISCOVERY",
-      liftedAt: null, 
-    },
-    data: {
-      liftedAt: new Date(), 
-    },
+  // 1. First, find the corresponding organisationId by userId
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { organisationId: true }
+  });
+
+  // 2. Use a transaction to guarantee atomic dual-writes
+  await prisma.$transaction(async (tx) => {
+    // Action A: Update the AppSuspension audit log (add liftedAt timestamp)
+    await tx.appSuspension.updateMany({
+      where: {
+        userId: userId,
+        appKey: "TALENT_DISCOVERY",
+        liftedAt: null, 
+      },
+      data: {
+        liftedAt: new Date(), 
+      },
+    });
+
+    // Action B: Revert the Organisation status back to APPROVED
+    if (user?.organisationId) {
+      await tx.organisation.update({
+        where: { id: user.organisationId },
+        data: { status: "APPROVED" },
+      });
+    }
   });
   
   revalidatePath(`/membership-dashboard/partner-users/${userId}/edit`);
-} // <--- The previously missing brace is closed here!
+}
 
 // Update organisation information (It is now outside, independent and safe)
-export async function updateOrganisation(orgId: string, userId: string, data: {
+export async function updateOrganisation(orgId: number, userId: string, data: {
   slug?: string;
   domain?: string;
   type?: string;
   status?: string;
 }) {
-  // 1. 增加严格的运行时验证 (Runtime Validation)
+  // 1. Apply strict runtime validation
   if (data.type && !Object.values(OrganisationType).includes(data.type as OrganisationType)) {
     throw new Error(`Invalid Organisation Type: ${data.type}`);
   }
@@ -48,9 +86,9 @@ export async function updateOrganisation(orgId: string, userId: string, data: {
     throw new Error(`Invalid Company Status: ${data.status}`);
   }
 
-  // 2. 验证通过后，安全地存入数据库
+  // 2. Save securely to the database upon successful validation
   await prisma.organisation.update({
-    where: { id: orgId },
+    where: { id: Number(orgId) },
     data: {
       ...(data.slug   !== undefined && { slug:   data.slug }),
       ...(data.domain !== undefined && { domain: data.domain }),

--- a/src/app/api/admin/partners/route.ts
+++ b/src/app/api/admin/partners/route.ts
@@ -13,12 +13,16 @@ export async function GET() {
     return NextResponse.json({ error: "Admin access required." }, { status: 403 });
   }
 
+  // 1. Expand query scope: Fetch the real status of the Organisation and AppSuspension records
   const partners = await prisma.user.findMany({
     where: {
       userStatus: "ACTIVE",
+      // To avoid missing any partners (e.g., Amazon, which might be set to OTHER or UNIVERSITY)
+      // We remove the strict 'type: "INDUSTRY"' restriction; as long as there is an organisationId, it's included
+      organisationId: { not: null },
       organisation: {
-        type: "INDUSTRY",
-      },
+        status: { not: "PENDING" }
+      }
     },
     select: {
       id: true,
@@ -26,11 +30,18 @@ export async function GET() {
       lastName: true,
       email: true,
       organisation: {
-        select: { name: true },
+        select: { 
+          name: true,
+          status: true // Fetch the company's real approval status
+        },
+      },
+      appSuspensions: { // Fetch penalty/suspension logs
+        where: { appKey: "TALENT_DISCOVERY", liftedAt: null }, // Only fetch currently active suspensions/bans
+        select: { reason: true },
+        take: 1, // One active penalty record is enough
       },
       memberships: {
         select: {
-          status: true,
           membershipTier: { select: { key: true } },
         },
         orderBy: { id: "desc" },
@@ -42,9 +53,18 @@ export async function GET() {
 
   const rows = partners.map((u) => {
     const membership = u.memberships[0];
-    const rawStatus = membership?.status ?? "active";
-    const status =
-      rawStatus === "suspended" || rawStatus === "banned" ? rawStatus : "active";
+    const orgStatus = u.organisation?.status;
+    const activeSuspension = u.appSuspensions[0];
+
+    // 2. Core logic: Calculate the "Effective Status"
+    let finalStatus = "active";
+    if (activeSuspension) {
+      // If there is an unlifted penalty record, prioritize showing the penalty status (suspended or banned)
+      finalStatus = activeSuspension.reason.toLowerCase();
+    } else if (orgStatus === "SUSPENDED" || orgStatus === "BANNED" || orgStatus === "PENDING") {
+      // Otherwise, fall back to the company's base approval status
+      finalStatus = orgStatus.toLowerCase();
+    }
 
     return {
       id: u.id,
@@ -55,7 +75,7 @@ export async function GET() {
         : undefined,
       email: u.email,
       appScope: "Talent Platform",
-      status,
+      status: finalStatus,
       history: [],
     };
   });

--- a/src/app/api/admin/pending-partners/route.ts
+++ b/src/app/api/admin/pending-partners/route.ts
@@ -15,8 +15,14 @@ export async function GET() {
       return NextResponse.json({ error: "Admin access required." }, { status: 403 });
     }
 
+    // find “user-userStatus : PENDING_APPROVAL” or “organisation-status: PENDING”
     const pendingUsers = await prisma.user.findMany({
-      where: { userStatus: "PENDING_APPROVAL" },
+      where: {
+        OR: [
+          { userStatus: "PENDING_APPROVAL" },
+          { organisation: { status: "PENDING" } }
+        ]
+      },
       select: {
         id: true,
         email: true,


### PR DESCRIPTION
### Summary
Fixed a visibility bug in the "Pending Company Registrations" panel where some pending companies were not showing up. 

### Root Cause & Fix
The `/api/admin/pending-partners` endpoint was exclusively querying for `userStatus: "PENDING_APPROVAL"`. This caused companies with an active user but a `PENDING` organisation status to be orphaned and invisible to admins.

**Changes:**
- Updated the Prisma query to use an `OR` condition, fetching accounts where **either** the User is pending **or** the linked Organisation is pending.
- This ensures a 100% accurate pending queue for the admin approval workflow.

### Testing
*(Please see attached screenshots showing the previously missing companies now correctly appearing in the Pending Panel)*